### PR TITLE
Feat: Set default Oracle connection string and update UI

### DIFF
--- a/OracleOptimizer/ViewModels/MainViewModel.cs
+++ b/OracleOptimizer/ViewModels/MainViewModel.cs
@@ -21,7 +21,7 @@ public partial class MainViewModel : ObservableObject
 
     // --- Observable Properties ---
     [ObservableProperty]
-    private string _connectionString = ""; // Provide a default or load from config
+    private string _connectionString = "cisconvert/cisconvert@dev5-mer-db:1521/TCTN_MASTER";
 
     [ObservableProperty]
     private string _originalSql = "";

--- a/OracleOptimizer/Views/MainView.xaml
+++ b/OracleOptimizer/Views/MainView.xaml
@@ -30,9 +30,8 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <Label Grid.Column="0" Content="Oracle Connection String:" VerticalAlignment="Center"/>
-                <TextBox Grid.Column="1" x:Name="ConnectionStringTextBox" Text="{Binding ConnectionString, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" Margin="5,0" ToolTip="Enter connection string in EZConnect format: hostname:port/service_name"/>
+                <TextBox Grid.Column="1" x:Name="ConnectionStringTextBox" Text="{Binding ConnectionString, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" Margin="5,0" ToolTip="Example format: username/password@hostname:port/service_name"/>
                 <!-- Connect button is optional, not implemented in ViewModel command -->
-                <Button Grid.Column="2" Content="Connect" Margin="5,0" Padding="10,2" IsEnabled="False"/>
             </Grid>
             <Grid Margin="0,5,0,0">
                 <Grid.ColumnDefinitions>

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ To use the Oracle SQL Optimizer application, follow these steps:
 1.  **Launch the Application**: Open the `OracleOptimizer.exe` application (after building it on a Windows machine with .NET 8 and WPF support).
 
 2.  **Enter Connection Details**:
-    *   **Oracle Connection String**: In the "Oracle Connection String" field, enter the connection string for your Oracle database.
-        *   The application supports standard Oracle connection strings. A common and simpler format to use is EZConnect (Easy Connect Naming Method).
-        *   **EZConnect Format**: `hostname:port/service_name`
-        *   Example (EZConnect): `your-oracle-host:1521/your_service_name`
+    *   **Oracle Connection String**: The application provides a default Oracle connection string. You may modify it as needed.
+        *   A common format, and the one used by the default string, is `username/password@hostname:port/service_name`.
+        *   Example: `cisconvert/cisconvert@dev5-mer-db:1521/TCTN_MASTER` (This is the default value provided in the application).
+        *   The application also supports other standard Oracle connection string formats, including the traditional detailed format.
         *   Example (Traditional): `Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=your-oracle-host)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=your-service-name)));User Id=your-user;Password=your-password;`
-        *   **Note**: The application UI includes a tooltip for the connection string field reminding users of the EZConnect format.
+        *   **Note**: The application UI includes a tooltip for the connection string field reminding users of the `username/password@hostname:port/service_name` format.
     *   **Gemini API Key**: In the "Gemini API Key" field, enter your Google Gemini API key. This is required to communicate with the optimization service.
 
 3.  **Input Original SQL Script**:


### PR DESCRIPTION
This commit introduces the following changes:

- Sets a default Oracle connection string (`cisconvert/cisconvert@dev5-mer-db:1521/TCTN_MASTER`) in `MainViewModel.cs`.
- Updates the `ToolTip` for the connection string input in `MainView.xaml` to guide you on the `username/password@hostname:port/service_name` format.
- Removes the non-functional 'Connect' button from `MainView.xaml`.
- Updates `README.md` to reflect the new default connection string, the recommended format, and the UI changes.